### PR TITLE
Let messg child elements inherit app's font family

### DIFF
--- a/index.css
+++ b/index.css
@@ -97,7 +97,7 @@
 .messg,
 .messg__button {
   color: #f5f5f5;
-  font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
+  font-family: inherit;
 }
 
 .messg__button {


### PR DESCRIPTION
Hi,

This will automatically inherit whatever font family is being used by the application.
I have to always override this property to match with application theme.

Thanks
